### PR TITLE
Concatenación de sentencias yum y clean posterior para reducir tamaño de imagen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,15 @@ MAINTAINER davidochobits davidochobits@colaboratorio.net
 
 ENV container docker
 
-RUN yum -y update
-RUN yum -y install sudo \
+RUN yum -y update \
+ && yum -y install sudo \
 	tar \
 	gzip \
 	openssh-clients \
 	java-1.7.0-openjdk-devel \
 	vi \
-	find
+	find \
+ && yum -y clean all
 
 RUN groupadd tomcat
 RUN useradd -M -s /bin/nologin -g tomcat -d /opt/tomcat tomcat


### PR DESCRIPTION
Al concatenar las sentencias RUN, forman parte de la misma capa  y con un 
`yum -y clean all` 
concatenado, el tamaño de la imagen pasa de ser 785 Mb a ser 643 Mb